### PR TITLE
[WIP] Rely on jekyll_pages_api_search's browserify hook

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -58,3 +58,10 @@ jekyll_pages_api_search:
     url:
       boost: 5
     body:
+
+  # If defined and browserify and uglifyify are installed, the plugin will
+  # generate a bundle to define the renderJekyllPagesApiSearchResults
+  # function.
+  browserify:
+    source: 'js/products.js'
+    target: 'js/products-bundle.js'

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -39,7 +39,6 @@ skip_index: true
     <!-- End Google Tag Manager -->
 
   </body>
-<script src="{{ site.baseurl }}/js/products-bundle.js"></script>
 <script>
 var JEKYLL_PAGES_API_SEARCH_UI_OPTIONS = {
   inputElementId: 'search-field',

--- a/_plugins/generator.rb
+++ b/_plugins/generator.rb
@@ -13,6 +13,8 @@ module PIF
         read_yaml(File.join(@base, '_layouts'), 'product.html')
         @data = @data.merge('product_info' => product_info)
         @data['title'] = product_info['name']
+        @data['tags'] = (product_info['top_keywords'] || []) +
+          (product_info['tags'] || [])
       end
     end
 

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
   "version": "1.0.0",
   "description": "This is the public repo for apps.gov, which is an active marketplace that helps gov employees evlauate and compare cloud-based products. Information on product's description, certifications, and contract vehicles are listed. Additionally, resources for tech comapnies to list their products and how to get started selling to the federal government can be found.",
   "main": "index.js",
-  "scripts": {
-    "make-bundle": "browserify -g uglifyify js/products.js -s renderJekyllPagesApiSearchResults -o js/products-bundle.js"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/presidential-innovation-fellows/apps-gov.git"


### PR DESCRIPTION
This depends on the behavior from the [mbland/jekyll_pages_api_search#genericize branch](https://github.com/mbland/jekyll_pages_api_search/tree/genericize), PR posted as 18F/jekyll_pages_api_search#24. With those changes, folks building this site need to have `browserify` and `uglifyify` installed, but don't need to run `npm run make-bundle` separately anymore.

Also includes tags in product pages to improve search.

cc: @stroupaloop 
