### PR TITLE
Require ruby >= 2.2.4; local build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Dependency Status](https://gemnasium.com/presidential-innovation-fellows/apps-gov.svg)](https://gemnasium.com/presidential-innovation-fellows/apps-gov)
 
-#Apps.Gov
+# Apps.Gov
 
 This is the public repo for apps.gov, which is an active marketplace that helps gov employees evlauate and compare cloud-based products. Information on product's description, certifications, and contract vehicles are listed. Additionally, resources for tech comapnies to list their products and how to get started selling to the federal government can be found.
 
@@ -16,7 +16,7 @@ All products are listed in `JSON` format. Updates can be made and submitted via 
 
 The format for listing your product `JSON` includes three sections: 1) required, 2) optional, and 3) attributes.
 
-####Required:
+#### Required:
 
     "slug": "product-file-name",
     "name": "product-name",
@@ -33,7 +33,7 @@ The format for listing your product `JSON` includes three sections: 1) required,
     "long_description": "Longer description of the product, which will be found on the product page.",
     "sales_poc": "sales-poc-email",
     
-####Optional:
+#### Optional:
 
     "twitter_handle": "twitter_handle",
     "facebook_url": "facebook_url",
@@ -41,7 +41,7 @@ The format for listing your product `JSON` includes three sections: 1) required,
     "angellist_name": "angellist_name",
     "youtube_video_id": "youtube_video_id",
     
-####Attributes: (add the appropriate ones that apply to your product)
+#### Attributes: (add the appropriate ones that apply to your product)
 
 **Contract Vehicles:**
 
@@ -87,13 +87,67 @@ The format for listing your product `JSON` includes three sections: 1) required,
     
 ### How to run this locally
 
-Clone this repo https://github.com/mbland/jekyll_pages_api_search/ and update your `Gemfile` to set the url path to this gem in your local directory
+1. Install [Ruby](https://www.ruby-lang.org/) on your system. This site
+   requires version 2.2.4 or greater. You can see if a compatible version is
+   already installed by running `ruby -v` in a terminal window.
 
-Within the apps-gov repo, run `./go init` which installs the npm modules (specified in package.json). Specifically, we need browserify and uglifyify to compile the custom js/products.js code into js/products-bundle.js, as specified in the jekyll_pages_api_search: browserify: property of _config.yml.
+   You may wish to install a version manager such as
+   [rbenv](https://github.com/rbenv/rbenv) to manage and install different
+   Ruby versions.
 
-Then, run `./go build` and `./go serve` to run the `bundler-aware` Jekyll build and serve commands, respectively. The .go script also sets the `NODE_PATH environment` variable to add the `node_modules` directory, so that the locally-installed browserify and uglifyify modules are discoverable.
-    
-Navigate to 
+1. Install [Node.js](https://nodejs.org/) on your system. This site requires
+   version 4.2 or greater or version 5 or greater. You can see if a compatible
+   version is already installed by running `node -v` in a terminal window. 
+
+   You may wish to install a version manager such as
+   [nvm](https://github.com/creationix/nvm) to manage and install different
+   Node.js versions.
+
+   *Why Node.js?* It's used to build the [lunr.js search
+   index](http://lunrjs.com/) and search user interface components supplied by
+   the [`jekyll_pages_api_search` gem](https://rubygems.org/gems/jekyll_pages_api_search).
+   We also use [browserify](https://www.npmjs.com/package/browserify)
+   and [uglifyify](https://www.npmjs.com/package/uglifyify) to compile the
+   custom [`js/products.js`](js/products.js]) code into
+   `js/products-bundle.js`, as specified in the
+   `jekyll_pages_api_search.browserify` property of
+   [`_config.yml`](_config.yml).
+
+1. Create a clone of this repository on your computer and change into its
+   directory:
+   ```sh
+   $ git clone https://github.com/presidential-innovation-fellows/apps-gov
+   $ cd apps-gov
+   ```
+
+1. Run `./go init` to install the [Ruby gems](https://rubygems.org/) specified
+   in the [`Gemfile`](Gemfile) and the [npm modules](https://www.npmjs.com/)
+   specified in [`package.json`](package.json).
+
+   The `./go` script is [Bundler](http://bundler.io)-aware, so you do not need
+   to run `bundle install` first.
+
+   *Windows users:* You may need to run the script as `ruby ./go init`
+   instead, and run other `./go` script commands in a similar fashion.
+
+1. Run `./go build` to build the site, and `./go serve` to build and serve the
+   site locally at http://127.0.0.1:4000.
+
+   These commands run `jekyll build` and `jekyll serve`, respectively. You can
+   pass command line arguments as you would to those bare commands.
+
+   *Why not just run `bundle exec jekyll serve`?* `./go init` and `./go serve`
+   perform the same environment setup as `bundle exec`, but the `./go` script
+   also sets the `NODE_PATH` environment variable to add the `node_modules`
+   directory, so that the locally-installed `browserify` and `uglifyify`
+   modules are discoverable. 
+
+   This is because `jekyll_pages_api_search` contains components that
+   `require()` these modules, but these components reside in a directory this
+   is neither a child nor a parent of the site. Consequently, [the default
+   Node.js module resolution
+   algorithm](https://nodejs.org/api/modules.html#modules_all_together) will
+   not discover the modules on its own.
 
 ## Appendix
 

--- a/go
+++ b/go
@@ -43,7 +43,7 @@ rescue LoadError
 end
 
 extend GoScript
-check_ruby_version '2.3.0'
+check_ruby_version '2.2.4'
 
 # END go_script 0.1.9 GENERATED CONTENT
 


### PR DESCRIPTION
2.3.0 isn't available on Windows yet, and 2.2.x is perfectly compatible. Also vastly improved the local build instructions. Confirmed that everything works on Windows 10 as well.

cc: @stroupaloop 
