### PR TITLE
Update slack:json contact email address

### DIFF
--- a/_data/products/slack.json
+++ b/_data/products/slack.json
@@ -12,7 +12,7 @@
     ],
     "short_description": "Slack is a team communication application providing services such as real-time\nmessaging, archiving, and search for modern teams.",
     "long_description": "Slack is a team communication application providing services such as real-time\nmessaging, archiving, and to search for modern teams. It offers one-on-one\nmessaging, private groups, persistent chat rooms, and direct messaging as well\nas group chats organized by topic. All content inside Slack is searchable from\none search box and it integrates with a number of third-party services,\nincluding Google Docs, Dropbox,\nHeroku,\nCrashlytics,\nGitHub, and Zendesk. Slack was\nlaunched in 2013 by Serguei Mourachov, Eric\nCostello, Cal Henderson, and\nStewart Butterfield. It is based in San\nFrancisco, C.A. The\napplication is available for Mac, PC, iOS, and\nAndroid.",
-    "sales_poc":"accounts@slack.com",
+    "sales_poc":"feedback@slack.com",
     "twitter_handle": "SlackHQ",
     "linkedin_id": 1612748,
     "youtube_video_id":"9RJZMSsH7-g",


### PR DESCRIPTION
Updated the preferred Slack Technologies contact email address for the Slack Apps.gov page.
