### PR TITLE
Capitalize the H in GitHub

### DIFF
--- a/_layouts/product.html
+++ b/_layouts/product.html
@@ -68,7 +68,7 @@ skip_index: false
 
 				<ul class="product-actions">
 					<li>
-						<a href="https://github.com/presidential-innovation-fellows/apps-gov/blob/master/_data/products/{{ product.slug | downcase }}.json" target="blank" id="github"><i class="fa fa-chevron-right pull-right"></i>Edit in Github</a>
+						<a href="https://github.com/presidential-innovation-fellows/apps-gov/blob/master/_data/products/{{ product.slug | downcase }}.json" target="blank" id="github"><i class="fa fa-chevron-right pull-right"></i>Edit in GitHub</a>
 					</li>
 					<li>
 						<a href="mailto:products-gov+abuse@gsa.gov" target="blank"><i class="fa fa-chevron-right pull-right"></i>Report this product</a>


### PR DESCRIPTION
For the "edit in Github" button, it should be "GitHub.
