### PR TITLE
Remove protocol from GitHub URL

### DIFF
--- a/_data/products/github.json
+++ b/_data/products/github.json
@@ -1,7 +1,7 @@
 {
     "slug": "github",
     "name": "GitHub",
-    "url": "https://government.github.com",
+    "url": "government.github.com",
     "logo_url": "//datafox-data.s3-us-west-1.amazonaws.com/images/cb_57fd815ad340c7aba975dd541a71fec6.png",
     "top_keywords": [
         "software",


### PR DESCRIPTION
This pull request removes the protocol from GitHub's listing URL to prevent the auto-prepended protocol from breaking the link:

``` html
                    <h4>
                        <a href="http://https://government.github.com"target="blank">
                            https://government.github.com
                            <i class="fa fa-external-link"></i>
                        </a>
                    </h4>
```

To note, it'd be nice if there were a way to link to an HTTPS site, without being redirected from the HTTP variant.
